### PR TITLE
cart validations complete

### DIFF
--- a/app/assets/stylesheets/components/_menu-card.scss
+++ b/app/assets/stylesheets/components/_menu-card.scss
@@ -85,7 +85,6 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
-
 /* Firefox */
 input[type=number] {
   -moz-appearance: textfield;

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -4,7 +4,7 @@ class OrderItemsController < ApplicationController
     order_item.quantity = params[:order_item][:quantity]
     order_item.menu_item = MenuItem.find(params[:item_id])
     order_item.order = Order.find(params[:id])
-    order_item.save!
+    order_item.save
     redirect_to menu_items_path
   end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,14 +1,14 @@
 class OrderItem < ApplicationRecord
-  before_validation :check_if_exists_in_order
   belongs_to :order
   belongs_to :menu_item
+  validates :quantity, presence: true, allow_blank: false
+  before_save :check_if_exists_in_order
 
   def check_if_exists_in_order
-    if OrderItem.find_by(order_id: self.order_id, menu_item_id: self.menu_item.id)
-      OrderItem.find_by(order_id: self.order_id, menu_item_id: self.menu_item.id).quantity = self.quantity
-      OrderItem.find_by(order_id: self.order_id, menu_item_id: self.menu_item.id).destroy
+    selected_item = OrderItem.find_by(order_id: self.order_id, menu_item_id: self.menu_item.id)
+    if selected_item
+      self.quantity = self.quantity + selected_item.quantity
+      selected_item.destroy
     end
   end
 end
-
-

--- a/app/views/menu_items/index.html.erb
+++ b/app/views/menu_items/index.html.erb
@@ -21,7 +21,7 @@
             <div class="add-button">
           <%= simple_form_for @order_item, url: order_items_path(@cart.id) do |f| %>
             <%= hidden_field_tag(:item_id, menu_item.id) %>
-            <%= f.input :quantity, label: "quantity"%>
+            <%= f.input :quantity, label: "Quantity", placeholder: '0', input_html: {value: 1}, as: :integer %>
             <%= f.button :button, ' Add to Cart', class: 'btn-icon' %>
             </div>
           <% end %>


### PR DESCRIPTION
When user presses add to cart button:
- If user doesn't edit the quantity field, one item will be added
- If user edits the quantity field to an integer, the integer quantity will be added
- if user leaves the quantity field empty (essentially leaving it value nil), the validations on the order_item model won't allow it, and a soft error will seamlessly reload the page.

UX = because the placeholder value equals zero, if a user tries to 'nil' the text box, the user will only interpret the value as adding 'zero' of this particular item to his cart